### PR TITLE
add credit card recurring in client & example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,15 @@ curl --include \
 
 4. localhost:8006/paid_invoice_from_xendit (callback url) get the paid invoice data.
 ```
+
+# Subscribe Credit Card Recurring Payment
+```
+cd src/
+php examples/subscribe_credit_card_recurring_payment_example.php [token_id] [initial_charge_amount] [initial_charge_external_id]
+```
+
+# Capture Subsequent Credit Card Recurring Payment
+```
+cd src/
+php examples/capture_subsequent_credit_card_recurring_payment_example.php [subscription_id] [amount] [external_id]
+```

--- a/src/XenditPHPClient.php
+++ b/src/XenditPHPClient.php
@@ -275,5 +275,60 @@
             $responseObject = json_decode($response, true);
             return $responseObject;
         }
+
+        function subscribeCreditCardRecurringPayment ($token_id, $initial_charge_amount, $initial_charge_external_id) {
+            $curl = curl_init();
+
+            $headers = array();
+            $headers[] = 'Content-Type: application/json';
+
+            $end_point = $this->server_domain.'/recurring_credit_card_subscription';
+
+            $data['token_id'] = $token_id;
+            $data['initial_charge_amount'] = $initial_charge_amount;
+            $data['initial_charge_external_id'] = $initial_charge_external_id;
+
+            $payload = json_encode($data);
+
+            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
+            curl_setopt($curl, CURLOPT_URL, $end_point);
+            curl_setopt($curl, CURLOPT_POST, true);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+            $response = curl_exec($curl);
+            curl_close($curl);
+
+            $responseObject = json_decode($response, true);
+            return $responseObject;
+        }
+
+        function captureSubsequentCreditCardRecurringPayment ($subscription_id, $amount, $external_id) {
+            $curl = curl_init();
+
+            $headers = array();
+            $headers[] = 'Content-Type: application/json';
+
+            $end_point = $this->server_domain.'/recurring_credit_card_subscription/'.$subscription_id.'/charges';
+
+            $data['amount'] = $amount;
+            $data['external_id'] = $external_id;
+
+            $payload = json_encode($data);
+
+            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
+            curl_setopt($curl, CURLOPT_URL, $end_point);
+            curl_setopt($curl, CURLOPT_POST, true);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+            $response = curl_exec($curl);
+            curl_close($curl);
+
+            $responseObject = json_decode($response, true);
+            return $responseObject;   
+        }
     }
 ?>

--- a/src/examples/capture_subsequent_credit_card_recurring_payment_example.php
+++ b/src/examples/capture_subsequent_credit_card_recurring_payment_example.php
@@ -1,0 +1,16 @@
+<?php
+    require('config/xendit_php_client_config.php');
+    require('XenditPHPClient.php');
+
+    $options['secret_api_key'] = constant('SECRET_API_KEY');
+
+    $xenditPHPClient = new XenditClient\XenditPHPClient($options);
+
+    $subscription_id = $argv[1];
+    $amount = $argv[2];
+    $external_id = $argv[3];
+
+    $response = $xenditPHPClient->captureSubsequentCreditCardRecurringPayment($subscription_id, $amount, $external_id);
+
+    print_r($response);
+?>

--- a/src/examples/subscribe_credit_card_recurring_payment_example.php
+++ b/src/examples/subscribe_credit_card_recurring_payment_example.php
@@ -1,0 +1,16 @@
+<?php
+    require('config/xendit_php_client_config.php');
+    require('XenditPHPClient.php');
+
+    $options['secret_api_key'] = constant('SECRET_API_KEY');
+
+    $xenditPHPClient = new XenditClient\XenditPHPClient($options);
+
+    $token_id = $argv[1];
+    $initial_charge_amount = $argv[2];
+    $initial_charge_external_id = $argv[3];
+
+    $response = $xenditPHPClient->subscribeCreditCardRecurringPayment($token_id, $initial_charge_amount, $initial_charge_external_id);
+
+    print_r($response);
+?>


### PR DESCRIPTION
Problem:
We create [new endpoint](https://github.com/xendit/xendit-api-gateway/pull/42) for recurring payment, so we need to add it in php clients

Solution:
Add client and example for subscribing recurring payment and capture subsequent recurring payment