### PR TITLE
add empty validation in creating callback virtual account

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ cd src/
 php examples/create_callback_virtual_account_example.php "CUSTOM_ID_2" "BCA" "Rizky"
 ```
 
+# Create Callback Virtual Account With Virtual Account Number Example : #
+```
+cd src/
+php examples/create_callback_virtual_account_example.php "CUSTOM_ID_2" "BCA" "Rizky" 100
+```
+
 # GET Balance Example : #
 ```
 cd src/

--- a/src/XenditPHPClient.php
+++ b/src/XenditPHPClient.php
@@ -91,7 +91,7 @@
             return $responseObject;            
         }
 
-        function createCallbackVirtualAccount ($external_id, $bank_code, $name, $virtual_account_number) {
+        function createCallbackVirtualAccount ($external_id, $bank_code, $name, $virtual_account_number = null) {
             $curl = curl_init();
 
             $headers = array();
@@ -102,7 +102,10 @@
             $data['external_id'] = $external_id;
             $data['bank_code'] = $bank_code;
             $data['name'] = $name;
-            $data['virtual_account_number'] = $virtual_account_number;
+
+            if (!empty($virtual_account_number)) {
+                $data['virtual_account_number'] = $virtual_account_number;
+            }
 
             $payload = json_encode($data);
 

--- a/src/examples/create_callback_virtual_account_with_virtual_account_number_example.php
+++ b/src/examples/create_callback_virtual_account_with_virtual_account_number_example.php
@@ -1,0 +1,16 @@
+<?php
+    require('config/xendit_php_client_config.php'); 
+    require('XenditPHPClient.php');
+    
+    $options['secret_api_key'] = constant('SECRET_API_KEY');
+
+    $xenditPHPClient = new XenditClient\XenditPHPClient($options);
+
+    $external_id = $argv[1];
+    $bank_code = $argv[2];
+    $name = $argv[3];
+    $virtual_account_number = $argv[4];
+
+    $response = $xenditPHPClient->createCallbackVirtualAccount($external_id, $bank_code, $name, $virtual_account_number);
+    print_r($response);
+?>


### PR DESCRIPTION
## Problems
Currrent `createCallbackVirtualAccount` didn't handle empty `virtual_account_number` options correctly

## Solutions
- Add empty `virtual_account_number` validation and example