### PR TITLE
Remove redundant curl request code

### DIFF
--- a/src/Helper/Util.php
+++ b/src/Helper/Util.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace XenditClient\Helper;
+
+class Util {
+	/**
+	 * [urlEncode description]
+	 * @param  [type] $arr    [description]
+	 * @param  [type] $prefix [description]
+	 * @return [type]         [description]
+	 */
+	public static function urlEncode($arr, $prefix = null)
+    {
+        if (!is_array($arr)) {
+            return $arr;
+        }
+        $r = array();
+        foreach ($arr as $k => $v) {
+            if (is_null($v)) {
+                continue;
+            }
+            if ($prefix) {
+                if ($k !== null && (!is_int($k) || is_array($v))) {
+                    $k = $prefix."[".$k."]";
+                } else {
+                    $k = $prefix."[]";
+                }
+            }
+            if (is_array($v)) {
+                $enc = self::urlEncode($v, $k);
+                if ($enc) {
+                    $r[] = $enc;
+                }
+            } else {
+                $r[] = urlencode($k)."=".urlencode($v);
+            }
+        }
+        return implode("&", $r);
+    }
+}

--- a/src/HttpClient/Curl.php
+++ b/src/HttpClient/Curl.php
@@ -33,7 +33,7 @@ class Curl {
 		    }
 		} elseif ($method == 'post') {
 			$opts[CURLOPT_POST] = 1;
-            $opts[CURLOPT_POSTFIELDS] = Util::urlEncode($params);
+			$opts[CURLOPT_POSTFIELDS] = Util::urlEncode($params);
 		}
 
 		$opts[CURLOPT_HTTPHEADER] = $headers;

--- a/src/HttpClient/Curl.php
+++ b/src/HttpClient/Curl.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace XenditClient\HttpClient;
+
+use XenditClient\Helper\Util;
+
+
+class Curl {
+	private $secret_api_key;
+
+	public function __construct($secret_api_key)
+	{
+		$this->secret_api_key = $secret_api_key;
+	}
+
+
+	/**
+	 * [request description]
+	 * @return [type] [description]
+	 */
+	public function request($method, $url, $headers, $params = null)
+	{
+		$curl = curl_init();
+		$method = strtolower($method);
+		$opts = array();
+
+		if ($method == 'get') {
+		    $opts[CURLOPT_HTTPGET] = 1;
+		    
+		    if (count($params) > 0) {
+		        $encoded = Util::urlEncode($params);
+		        $url = "$url?$encoded";
+		    }
+		} elseif ($method == 'post') {
+			$opts[CURLOPT_POST] = 1;
+            $opts[CURLOPT_POSTFIELDS] = Util::urlEncode($params);
+		}
+
+		$opts[CURLOPT_HTTPHEADER] = $headers;
+		$opts[CURLOPT_USERPWD] = $this->secret_api_key.":";
+		$opts[CURLOPT_URL] = $url;
+		$opts[CURLOPT_RETURNTRANSFER] = true;
+
+		curl_setopt_array($curl, $opts);
+		$response = curl_exec($curl);
+		curl_close($curl);
+
+		$responseObject = json_decode($response, true);
+
+		return $responseObject;             
+	}
+}

--- a/src/XenditPHPClient.php
+++ b/src/XenditPHPClient.php
@@ -15,8 +15,6 @@ class XenditPHPClient {
     }
 
     function createInvoice ($external_id, $amount, $payer_email, $description, $invoice_options = null) {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 
@@ -37,8 +35,6 @@ class XenditPHPClient {
     }
 
     function createDisbursement ($external_id, $amount, $bank_code, $account_holder_name, $account_number, $disbursement_options = null) {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 
@@ -60,8 +56,6 @@ class XenditPHPClient {
     }
 
     function getVirtualAccountBanks () {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 
@@ -71,8 +65,6 @@ class XenditPHPClient {
     }
 
     function createCallbackVirtualAccount ($external_id, $bank_code, $name, $virtual_account_number = null) {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 
@@ -92,8 +84,6 @@ class XenditPHPClient {
     }
 
     function getDisbursement ($disbursement_id) {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 
@@ -103,8 +93,6 @@ class XenditPHPClient {
     }
 
     function getAvailableDisbursementBanks () {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 
@@ -114,8 +102,6 @@ class XenditPHPClient {
     }
 
     function getInvoice ($invoice_id) {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 
@@ -134,8 +120,6 @@ class XenditPHPClient {
     }
 
     function captureCreditCardPayment ($external_id, $token_id, $amount) {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 
@@ -151,8 +135,6 @@ class XenditPHPClient {
     }
 
     function issueCreditCardRefund ($credit_card_charge_id, $amount, $external_id, $options = null) {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 
@@ -171,8 +153,6 @@ class XenditPHPClient {
     }
 
     function validateBankAccountHolderName ($bank_account_number, $bank_code) {
-        $curl = curl_init();
-
         $headers = array();
         $headers[] = 'Content-Type: application/json';
 

--- a/src/XenditPHPClient.php
+++ b/src/XenditPHPClient.php
@@ -1,296 +1,189 @@
 <?php
 
-    namespace XenditClient;
+namespace XenditClient;
 
-    class XenditPHPClient {
-        function __construct ($options) {
-            $this->server_domain = 'https://api.xendit.co';
-            $this->secret_api_key = $options['secret_api_key'];
-        }
+use XenditClient\HttpClient\Curl;
 
-        function createInvoice ($external_id, $amount, $payer_email, $description, $invoice_options = null) {
-            $curl = curl_init();
 
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
+class XenditPHPClient {
 
-            $end_point = $this->server_domain.'/v2/invoices';
+    function __construct ($options) {
+        $this->server_domain = 'https://api.xendit.co';
+        $this->secret_api_key = $options['secret_api_key'];
 
-            $data['external_id'] = $external_id;
-            $data['amount'] = (int)$amount;
-            $data['payer_email'] = $payer_email;
-            $data['description'] = $description;
-
-            if (!empty($invoice_options['callback_virtual_account_id'])) {
-                $data['callback_virtual_account_id'] = $invoice_options['callback_virtual_account_id'];
-            }
-
-            $payload = json_encode($data);
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_POST, true);
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;
-        }
-
-        function createDisbursement ($external_id, $amount, $bank_code, $account_holder_name, $account_number, $disbursement_options = null) {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            if (!empty($disbursement_options['X-IDEMPOTENCY-KEY'])) {
-                array_push($headers, 'X-IDEMPOTENCY-KEY: '.$disbursement_options['X-IDEMPOTENCY-KEY']);
-            }
-
-            $end_point = $this->server_domain.'/disbursements';
-
-            $data['external_id'] = $external_id;
-            $data['amount'] = (int)$amount;
-            $data['bank_code'] = $bank_code;
-            $data['account_holder_name'] = $account_holder_name;
-            $data['account_number'] = $account_number;
-
-            $payload = json_encode($data);
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_POST, true);
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;
-        }
-
-        function getVirtualAccountBanks () {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            $end_point = $this->server_domain.'/available_virtual_account_banks';
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;            
-        }
-
-        function createCallbackVirtualAccount ($external_id, $bank_code, $name, $virtual_account_number = null) {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            $end_point = $this->server_domain.'/callback_virtual_accounts';
-
-            $data['external_id'] = $external_id;
-            $data['bank_code'] = $bank_code;
-            $data['name'] = $name;
-
-            if (!empty($virtual_account_number)) {
-                $data['virtual_account_number'] = $virtual_account_number;
-            }
-
-            $payload = json_encode($data);
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_POST, true);
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;
-        }
-
-        function getDisbursement ($disbursement_id) {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            $end_point = $this->server_domain.'/disbursements/'.$disbursement_id;
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;
-        }
-
-        function getAvailableDisbursementBanks () {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            $end_point = $this->server_domain.'/available_disbursements_banks';
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;             
-        }
-
-        function getInvoice ($invoice_id) {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            $end_point = $this->server_domain.'/v2/invoices/'.$invoice_id;
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;
-        }
-
-        function getBalance () {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            $end_point = $this->server_domain.'/balance';
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;
-        }
-
-        function captureCreditCardPayment ($external_id, $token_id, $amount) {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            $end_point = $this->server_domain.'/credit_card_charges';
-
-            $data['external_id'] = $external_id;
-            $data['token_id'] = $token_id;
-            $data['amount'] = $amount;
-
-            $payload = json_encode($data);
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_POST, true);
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;
-        }
-
-        function issueCreditCardRefund ($credit_card_charge_id, $amount, $external_id, $options = null) {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            if (!empty($options['X-IDEMPOTENCY-KEY'])) {
-                array_push($headers, 'X-IDEMPOTENCY-KEY: '.$options['X-IDEMPOTENCY-KEY']);
-            }
-
-            $end_point = $this->server_domain.'/credit_card_charges/'.$credit_card_charge_id.'/refunds';
-
-            $data['amount'] = $amount;
-            $data['external_id'] = $external_id;
-
-            $payload = json_encode($data);
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_POST, true);
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;
-        }
-
-        function validateBankAccountHolderName ($bank_account_number, $bank_code) {
-            $curl = curl_init();
-
-            $headers = array();
-            $headers[] = 'Content-Type: application/json';
-
-            $end_point = $this->server_domain.'/bank_account_data_requests';
-
-            $data['bank_account_number'] = $bank_account_number;
-            $data['bank_code'] = $bank_code;
-
-            $payload = json_encode($data);
-
-            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($curl, CURLOPT_USERPWD, $this->secret_api_key.":");
-            curl_setopt($curl, CURLOPT_URL, $end_point);
-            curl_setopt($curl, CURLOPT_POST, true);
-            curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
-            curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-
-            $response = curl_exec($curl);
-            curl_close($curl);
-
-            $responseObject = json_decode($response, true);
-            return $responseObject;
-        }
+        $this->xenditCurl = new Curl($this->secret_api_key);
     }
+
+    function createInvoice ($external_id, $amount, $payer_email, $description, $invoice_options = null) {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        $end_point = $this->server_domain.'/v2/invoices';
+
+        $data['external_id'] = $external_id;
+        $data['amount'] = (int)$amount;
+        $data['payer_email'] = $payer_email;
+        $data['description'] = $description;
+
+        if (!empty($invoice_options['callback_virtual_account_id'])) {
+            $data['callback_virtual_account_id'] = $invoice_options['callback_virtual_account_id'];
+        }
+        
+        $payload = json_encode($data);
+
+        return $this->xenditCurl->request('post', $end_point, $headers, $payload);
+    }
+
+    function createDisbursement ($external_id, $amount, $bank_code, $account_holder_name, $account_number, $disbursement_options = null) {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        if (!empty($disbursement_options['X-IDEMPOTENCY-KEY'])) {
+            array_push($headers, 'X-IDEMPOTENCY-KEY: '.$disbursement_options['X-IDEMPOTENCY-KEY']);
+        }
+
+        $end_point = $this->server_domain.'/disbursements';
+
+        $data['external_id'] = $external_id;
+        $data['amount'] = (int)$amount;
+        $data['bank_code'] = $bank_code;
+        $data['account_holder_name'] = $account_holder_name;
+        $data['account_number'] = $account_number;
+
+        $payload = json_encode($data);
+
+        return $this->xenditCurl->request('post', $end_point, $headers, $payload);
+    }
+
+    function getVirtualAccountBanks () {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        $end_point = $this->server_domain.'/available_virtual_account_banks';
+        
+        return $this->xenditCurl->request('get', $end_point, $headers); 
+    }
+
+    function createCallbackVirtualAccount ($external_id, $bank_code, $name, $virtual_account_number = null) {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        $end_point = $this->server_domain.'/callback_virtual_accounts';
+
+        $data['external_id'] = $external_id;
+        $data['bank_code'] = $bank_code;
+        $data['name'] = $name;
+
+        if (!empty($virtual_account_number)) {
+            $data['virtual_account_number'] = $virtual_account_number;
+        }
+
+        $payload = json_encode($data);
+
+        return $this->xenditCurl->request('post', $end_point, $headers, $payload);
+    }
+
+    function getDisbursement ($disbursement_id) {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        $end_point = $this->server_domain.'/disbursements/'.$disbursement_id;
+
+        return $this->xenditCurl->request('get', $end_point, $headers);
+    }
+
+    function getAvailableDisbursementBanks () {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        $end_point = $this->server_domain.'/available_disbursements_banks';
+
+        return $this->xenditCurl->request('get', $end_point, $headers);            
+    }
+
+    function getInvoice ($invoice_id) {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        $end_point = $this->server_domain.'/v2/invoices/'.$invoice_id;
+
+        return $this->xenditCurl->request('get', $end_point, $headers);
+    }
+
+    function getBalance () {
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        $end_point = $this->server_domain.'/balance';
+
+        return $this->xenditCurl->request('get', $end_point, $headers);
+    }
+
+    function captureCreditCardPayment ($external_id, $token_id, $amount) {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        $end_point = $this->server_domain.'/credit_card_charges';
+
+        $data['external_id'] = $external_id;
+        $data['token_id'] = $token_id;
+        $data['amount'] = $amount;
+
+        $payload = json_encode($data);
+
+        return $this->xenditCurl->request('post', $end_point, $headers, $payload);
+    }
+
+    function issueCreditCardRefund ($credit_card_charge_id, $amount, $external_id, $options = null) {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        if (!empty($options['X-IDEMPOTENCY-KEY'])) {
+            array_push($headers, 'X-IDEMPOTENCY-KEY: '.$options['X-IDEMPOTENCY-KEY']);
+        }
+
+        $end_point = $this->server_domain.'/credit_card_charges/'.$credit_card_charge_id.'/refunds';
+
+        $data['amount'] = $amount;
+        $data['external_id'] = $external_id;
+
+        $payload = json_encode($data);
+
+        return $this->xenditCurl->request('post', $end_point, $headers, $payload);
+    }
+
+    function validateBankAccountHolderName ($bank_account_number, $bank_code) {
+        $curl = curl_init();
+
+        $headers = array();
+        $headers[] = 'Content-Type: application/json';
+
+        $end_point = $this->server_domain.'/bank_account_data_requests';
+
+        $data['bank_account_number'] = $bank_account_number;
+        $data['bank_code'] = $bank_code;
+
+        $payload = json_encode($data);
+
+        return $this->xenditCurl->request('post', $end_point, $headers, $payload);
+    }
+}
 ?>

--- a/src/examples/capture_credit_card_payment_example.php
+++ b/src/examples/capture_credit_card_payment_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
 
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/create_callback_virtual_account_example.php
+++ b/src/examples/create_callback_virtual_account_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php'); 
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/create_callback_virtual_account_with_virtual_account_number_example.php
+++ b/src/examples/create_callback_virtual_account_with_virtual_account_number_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php'); 
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/create_disbursement_example.php
+++ b/src/examples/create_disbursement_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/create_disbursement_with_idempotency_key_example.php
+++ b/src/examples/create_disbursement_with_idempotency_key_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/create_invoice_example.php
+++ b/src/examples/create_invoice_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/create_invoice_with_callback_virtual_account_id_example.php
+++ b/src/examples/create_invoice_with_callback_virtual_account_id_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/get_available_disbursement_banks.php
+++ b/src/examples/get_available_disbursement_banks.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/get_balance_example.php
+++ b/src/examples/get_balance_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+	require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/get_disbursement_example.php
+++ b/src/examples/get_disbursement_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/get_invoice_example.php
+++ b/src/examples/get_invoice_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/get_virtual_account_banks.php
+++ b/src/examples/get_virtual_account_banks.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/include_autoload.php
+++ b/src/examples/include_autoload.php
@@ -1,0 +1,13 @@
+<?php
+
+require('config/xendit_php_client_config.php');
+	
+$autoloadPath = '../vendor/autoload.php';
+
+if (file_exists($autoloadPath)) {
+  	require($autoloadPath);
+} else {
+	require('XenditPHPClient.php');
+	require('HttpClient/Curl.php');
+	require('Helper/Util.php');
+}

--- a/src/examples/issue_credit_card_refund_example.php
+++ b/src/examples/issue_credit_card_refund_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
 
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/issue_credit_card_refund_with_idempotency_example.php
+++ b/src/examples/issue_credit_card_refund_with_idempotency_example.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
 
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 

--- a/src/examples/validate_bank_account_holder_name.php
+++ b/src/examples/validate_bank_account_holder_name.php
@@ -1,6 +1,5 @@
 <?php
-    require('config/xendit_php_client_config.php');
-    require('XenditPHPClient.php');
+    require('examples/include_autoload.php');
     
     $options['secret_api_key'] = constant('SECRET_API_KEY');
 


### PR DESCRIPTION
I've simplified curl request code on each API method in XenditPHPClient.php, and i'm trying to implement PSR-2 and also PSR-4, but don't worry i'm still keep the current setting (without composer autoloading).